### PR TITLE
MERGE BEFORE PRESENTATION AT OWN RISK

### DIFF
--- a/src/components/FileExplorerToolbar/FileExplorerToolbar.tsx
+++ b/src/components/FileExplorerToolbar/FileExplorerToolbar.tsx
@@ -95,7 +95,7 @@ const FileExplorerToolbar: React.FC<FileExplorerToolbarProps> = ({
       }
 
       // Refetch tags to update all components
-      await fetchTags();
+      await fetchTags(true); // ensure global cache updates once
       if (onRefetchTags) {
         await onRefetchTags();
       }
@@ -139,7 +139,7 @@ const FileExplorerToolbar: React.FC<FileExplorerToolbarProps> = ({
       }
 
       // Refetch tags to update all components
-      await fetchTags();
+      await fetchTags(true); // ensure global cache updates once
       if (onRefetchTags) {
         await onRefetchTags();
       }
@@ -187,7 +187,7 @@ const FileExplorerToolbar: React.FC<FileExplorerToolbarProps> = ({
     setIsCreatingTag(true);
     try {
       const newTag = await createTag(filterInputValue.trim());
-      await fetchTags();
+      await fetchTags(true); // refresh cache for all consumers
       if (onRefetchTags) {
         await onRefetchTags();
       }

--- a/src/components/FileListItem/FileListItem.tsx
+++ b/src/components/FileListItem/FileListItem.tsx
@@ -151,13 +151,6 @@ const FileListItem: React.FC<Props> = ({
                 }}
                 role={item.itemType === 'folder' ? 'button' : undefined}
                 tabIndex={item.itemType === 'folder' ? 0 : undefined}
-                onClick={() => {
-                  if (item.itemType === 'folder') {
-                    onOpen?.(item.id, item.name);
-                  } else if (onPreview) {
-                    onPreview(item.id);
-                  }
-                }}
                 onKeyDown={(e) => {
                   if (
                     item.itemType === 'folder' &&

--- a/src/components/FileViewer/FileViewer.tsx
+++ b/src/components/FileViewer/FileViewer.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import {
   Box,
   Typography,
@@ -41,6 +41,8 @@ const CONVERTIBLE_TYPES = [
   'application/msword', // .doc
   'application/vnd.openxmlformats-officedocument.presentationml.presentation', // .pptx
   'application/vnd.ms-powerpoint', // .ppt
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', // .xlsx
+  'application/vnd.ms-excel', // .xls
 ];
 
 const FileViewer: React.FC<FileViewerProps> = ({
@@ -57,21 +59,38 @@ const FileViewer: React.FC<FileViewerProps> = ({
   const api = useDmsApiSelector();
   const [textContent, setTextContent] = useState<string | null>(null);
   const [internalLoading, setInternalLoading] = useState(false);
+  // Track previous fileUrl to differentiate between same file reopening vs new file
+  const prevFileUrlRef = useRef<string | null>(null);
   const isLoading = loading ?? internalLoading;
 
-  // Reset loading state when dialog opens with new file
-  useEffect(() => {
-    if (open && fileUrl) {
+  // Set loading BEFORE first paint when a new file starts loading to avoid late flicker.
+  useLayoutEffect(() => {
+    if (!open) return;
+    // New file selected or newly opened
+    const isNewFile = fileUrl && prevFileUrlRef.current !== fileUrl;
+    if (isNewFile) {
+      prevFileUrlRef.current = fileUrl;
+      setTextContent(null); // reset any previous text content
       setInternalLoading(true);
-      setTextContent(null);
+      setLoading?.(true);
     }
-  }, [open, fileUrl]);
+  }, [open, fileUrl, setLoading]);
+
+  // If dialog was closed, reset loading refs
+  useEffect(() => {
+    if (!open) {
+      setInternalLoading(false);
+    }
+  }, [open]);
 
   // Load text content for text files
   useEffect(() => {
     if (open && fileType?.startsWith('text/') && fileUrl) {
       // Remove fragment identifier for fetch
       const cleanUrl = fileUrl.split('#')[0];
+      // Ensure loading state (in case same URL triggers refetch)
+      setInternalLoading(true);
+      setLoading?.(true);
       fetch(cleanUrl)
         .then((response) => response.text())
         .then((text) => {
@@ -115,12 +134,12 @@ const FileViewer: React.FC<FileViewerProps> = ({
 
   const canPreview = (type: string | null): boolean => {
     if (!type) return false;
-    return (
-      ALLOWED_PREVIEW_TYPES.includes(type) ||
-      CONVERTIBLE_TYPES.includes(type) ||
-      type.startsWith('image/') ||
-      type.startsWith('text/')
-    );
+    // Be explicit: allow images, allowed list, convertible list.
+    // Do NOT generally allow text/* to avoid odd HTML/CSV rendering.
+    if (ALLOWED_PREVIEW_TYPES.includes(type)) return true;
+    if (CONVERTIBLE_TYPES.includes(type)) return true;
+    if (type.startsWith('image/')) return true;
+    return false;
   };
 
   const renderPreview = () => {
@@ -184,9 +203,15 @@ const FileViewer: React.FC<FileViewerProps> = ({
               </Typography>
             </Box>
           )}
+          {/* Hide iframe visually until loaded to reduce layout jank */}
           <iframe
             src={fileUrl}
-            style={{ width: '100%', height: '80vh', border: 'none' }}
+            style={{
+              width: '100%',
+              height: '80vh',
+              border: 'none',
+              visibility: isLoading ? 'hidden' : 'visible',
+            }}
             title="PDF Preview"
             onLoad={() => {
               setLoading?.(false);
@@ -232,7 +257,11 @@ const FileViewer: React.FC<FileViewerProps> = ({
           <img
             src={fileUrl}
             alt={fileName ?? 'preview'}
-            style={{ maxWidth: '100%', maxHeight: '80vh' }}
+            style={{
+              maxWidth: '100%',
+              maxHeight: '80vh',
+              visibility: isLoading ? 'hidden' : 'visible',
+            }}
             onLoad={() => {
               setLoading?.(false);
               setInternalLoading(false);
@@ -275,9 +304,12 @@ const FileViewer: React.FC<FileViewerProps> = ({
               backgroundColor: '#f5f5f5',
               padding: '1rem',
               margin: 0,
+              opacity: isLoading ? 0.3 : 1,
+              transition: 'opacity 0.2s ease',
             }}
           >
-            {textContent || 'Loading...'}
+            {textContent ||
+              t('documentManagement.viewer.loading', 'Loading preview...')}
           </pre>
         </Box>
       );

--- a/src/components/StudyGroupSelector/StudyGroupSelector.tsx
+++ b/src/components/StudyGroupSelector/StudyGroupSelector.tsx
@@ -101,41 +101,43 @@ const StudyGroupSelector: React.FC<Props> = ({
           }
           renderValue={(selected) => (
             <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
-              {selected.map((groupName) => (
-                <Chip
-                  key={groupName}
-                  label={groupName}
-                  onMouseDown={(e) => {
-                    e.stopPropagation();
-                  }}
-                  onDelete={
-                    !isRestricted || selectedGroupsCount > 1
-                      ? (e) => {
-                          e.preventDefault();
-                          e.stopPropagation();
-                          handleDelete(groupName);
-                        }
-                      : undefined
-                  }
-                  disabled={disabled}
-                  sx={{
-                    backgroundColor: '#002E6D',
-                    color: '#ffffff',
-                    '& .MuiChip-deleteIcon': {
-                      color: 'rgba(255, 255, 255, 0.7)',
-                      '&:hover': {
-                        color: '#ffffff',
-                      },
-                      pointerEvents: 'auto',
-                    },
-                    '&.Mui-disabled': {
-                      opacity: 0.6,
+              {[...selected]
+                .sort((a, b) => a.localeCompare(b))
+                .map((groupName) => (
+                  <Chip
+                    key={groupName}
+                    label={groupName}
+                    onMouseDown={(e) => {
+                      e.stopPropagation();
+                    }}
+                    onDelete={
+                      !isRestricted || selectedGroupsCount > 1
+                        ? (e) => {
+                            e.preventDefault();
+                            e.stopPropagation();
+                            handleDelete(groupName);
+                          }
+                        : undefined
+                    }
+                    disabled={disabled}
+                    sx={{
                       backgroundColor: '#002E6D',
                       color: '#ffffff',
-                    },
-                  }}
-                />
-              ))}
+                      '& .MuiChip-deleteIcon': {
+                        color: 'rgba(255, 255, 255, 0.7)',
+                        '&:hover': {
+                          color: '#ffffff',
+                        },
+                        pointerEvents: 'auto',
+                      },
+                      '&.Mui-disabled': {
+                        opacity: 0.6,
+                        backgroundColor: '#002E6D',
+                        color: '#ffffff',
+                      },
+                    }}
+                  />
+                ))}
             </Box>
           )}
         >

--- a/src/components/TagEditor/TagEditor.tsx
+++ b/src/components/TagEditor/TagEditor.tsx
@@ -51,11 +51,7 @@ const TagEditor: React.FC<Props> = ({
   // Initialize selected tags when dialog opens or currentTags change
   React.useEffect(() => {
     if (open) {
-      // Refresh tags from server when dialog opens
-      fetchTags();
-
-      // Filter currentTags to only include tags that still exist
-      // This handles the case where a tag was deleted while the dialog was closed
+      // Kein sofortiger Refetch: useTags lädt initial bzw. liefert Cache
       const validTags = currentTags.filter((currentTag) =>
         availableTags.some(
           (availableTag) => availableTag.uuid === currentTag.uuid
@@ -63,7 +59,7 @@ const TagEditor: React.FC<Props> = ({
       );
       setSelectedTags(validTags);
     }
-  }, [open, currentTags, fetchTags]);
+  }, [open, currentTags, availableTags]);
 
   // Update selected tags when availableTags changes (e.g., after tag deletion)
   React.useEffect(() => {
@@ -115,7 +111,7 @@ const TagEditor: React.FC<Props> = ({
       setSelectedTags([...selectedTags, newTag]);
     }
     // Refetch tags to ensure the list is up-to-date
-    await fetchTags();
+    await fetchTags(true); // force refresh after creating a new tag
     // Notify parent to refresh
     if (onTagsChanged) {
       await onTagsChanged();
@@ -125,7 +121,7 @@ const TagEditor: React.FC<Props> = ({
 
   // Handle when tags are updated in AddTagDialog
   const handleTagsUpdated = async () => {
-    await fetchTags();
+    await fetchTags(true); // force refresh after tags updated in dialog
     // Notify parent to refresh document list
     if (onTagsChanged) {
       await onTagsChanged();

--- a/src/hooks/useDmsApiMock.ts
+++ b/src/hooks/useDmsApiMock.ts
@@ -136,126 +136,130 @@ export default function createMockApi() {
     infFolder.subfolders.push(binId);
 
     // Wirtschaftstrends.pptx und ETFs_explained.docx nur für BIN-T23
-    const wirtschaftId = 'pptx-23';
-    const wirtschaftDoc: Doc = {
-      id: wirtschaftId,
-      name: 'Wirtschaftstrends.pptx',
-      size: 500000,
-      createdDate: nowIso(),
-      type: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
-      parentId: binId,
-      tags: [tagId1, tagId2],
-    };
-    documents.set(wirtschaftId, wirtschaftDoc);
-    binFolder.documents.push(wirtschaftId);
-
-    const etfsId = 'docx-etfs-23';
-    const etfsDoc: Doc = {
-      id: etfsId,
-      name: 'ETFs_explained.docx',
-      size: 42000,
-      createdDate: nowIso(),
-      type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-      parentId: binId,
-    };
-    documents.set(etfsId, etfsDoc);
-    binFolder.documents.push(etfsId);
-
-    // F1-FX Unterordner und PDF-Dokumente
-    for (let f = 1; f <= bin.fCount; f++) {
-      const fId = `bin-${bin.jahr}-f${f}`;
-      const fFolder: Folder = {
-        id: fId,
-        name: `F${f}`,
+    if (bin.jahr === '23') {
+      const wirtschaftId = 'pptx-23';
+      const wirtschaftDoc: Doc = {
+        id: wirtschaftId,
+        name: 'Wirtschaftstrends.pptx',
+        size: 500000,
+        createdDate: nowIso(),
+        type: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
         parentId: binId,
-        createdDate: nowIso(),
-        subfolders: [],
-        documents: [],
+        tags: [tagId1, tagId2],
       };
-      folders.set(fId, fFolder);
-      binFolder.subfolders.push(fId);
+      documents.set(wirtschaftId, wirtschaftDoc);
+      binFolder.documents.push(wirtschaftId);
 
-      // PDF-Dokument für F-Ordner
-      const pdfId = `pdf-${bin.jahr}-f${f}`;
-      const pdfDoc: Doc = {
-        id: pdfId,
-        name: `Stundenplan_${bin.name}-F${f}_SoSe25.pdf`,
-        size: 1048576,
+      const etfsId = 'docx-etfs-23';
+      const etfsDoc: Doc = {
+        id: etfsId,
+        name: 'ETFs_explained.docx',
+        size: 42000,
         createdDate: nowIso(),
-        type: 'application/pdf',
-        parentId: fId,
+        type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        parentId: binId,
       };
-      documents.set(pdfId, pdfDoc);
-      fFolder.documents.push(pdfId);
+      documents.set(etfsId, etfsDoc);
+      binFolder.documents.push(etfsId);
+    }
 
-      // Verschachtelte Unterordner für F2 nur in BIN-T23
-      if (f === 2 && bin.jahr === '23') {
-        const subfolderNames = [
-          'Wie',
-          'ist',
-          'das',
-          'eigentlich',
-          'mit',
-          'ganz',
-          'vielen',
-          'Unterordnern',
-        ];
-        let parentSubId = fId;
-        subfolderNames.forEach((name, idx) => {
-          const subId = `${fId}-sub${idx}`;
-          const subFolder: Folder = {
-            id: subId,
-            name,
-            parentId: parentSubId,
+    // F1-FX Unterordner und PDF-Dokumente nur für BIN-T23
+    if (bin.jahr === '23') {
+      for (let f = 1; f <= bin.fCount; f++) {
+        const fId = `bin-${bin.jahr}-f${f}`;
+        const fFolder: Folder = {
+          id: fId,
+          name: `F${f}`,
+          parentId: binId,
+          createdDate: nowIso(),
+          subfolders: [],
+          documents: [],
+        };
+        folders.set(fId, fFolder);
+        binFolder.subfolders.push(fId);
+
+        // PDF-Dokument für F-Ordner
+        const pdfId = `pdf-${bin.jahr}-f${f}`;
+        const pdfDoc: Doc = {
+          id: pdfId,
+          name: `Stundenplan_${bin.name}-F${f}_SoSe25.pdf`,
+          size: 1048576,
+          createdDate: nowIso(),
+          type: 'application/pdf',
+          parentId: fId,
+        };
+        documents.set(pdfId, pdfDoc);
+        fFolder.documents.push(pdfId);
+
+        // Verschachtelte Unterordner für F2 nur in BIN-T23
+        if (f === 2) {
+          const subfolderNames = [
+            'Wie',
+            'ist',
+            'das',
+            'eigentlich',
+            'mit',
+            'ganz',
+            'vielen',
+            'Unterordnern',
+          ];
+          let parentSubId = fId;
+          subfolderNames.forEach((name, idx) => {
+            const subId = `${fId}-sub${idx}`;
+            const subFolder: Folder = {
+              id: subId,
+              name,
+              parentId: parentSubId,
+              createdDate: nowIso(),
+              subfolders: [],
+              documents: [],
+            };
+            folders.set(subId, subFolder);
+            const parentFolder = folders.get(parentSubId);
+            if (parentFolder) parentFolder.subfolders.push(subId);
+            parentSubId = subId;
+          });
+          // Test-Ordner im letzten Unterordner anlegen und Datei hineinlegen
+          const lastSubId = `${fId}-sub${subfolderNames.length - 1}`;
+          const testFolderId = `${lastSubId}-test`;
+          const testFolder: Folder = {
+            id: testFolderId,
+            name: 'Test',
+            parentId: lastSubId,
             createdDate: nowIso(),
             subfolders: [],
             documents: [],
           };
-          folders.set(subId, subFolder);
-          const parentFolder = folders.get(parentSubId);
-          if (parentFolder) parentFolder.subfolders.push(subId);
-          parentSubId = subId;
-        });
-        // Test-Ordner im letzten Unterordner anlegen und Datei hineinlegen
-        const lastSubId = `${fId}-sub${subfolderNames.length - 1}`;
-        const testFolderId = `${lastSubId}-test`;
-        const testFolder: Folder = {
-          id: testFolderId,
-          name: 'Test',
-          parentId: lastSubId,
-          createdDate: nowIso(),
-          subfolders: [],
-          documents: [],
-        };
-        folders.set(testFolderId, testFolder);
-        const lastSubFolder = folders.get(lastSubId);
-        if (lastSubFolder) lastSubFolder.subfolders.push(testFolderId);
+          folders.set(testFolderId, testFolder);
+          const lastSubFolder = folders.get(lastSubId);
+          if (lastSubFolder) lastSubFolder.subfolders.push(testFolderId);
 
-        // Scrum-Ordner im Test-Ordner anlegen
-        const scrumFolderId = `${testFolderId}-design`;
-        const scrumFolder: Folder = {
-          id: scrumFolderId,
-          name: 'Design',
-          parentId: testFolderId,
-          createdDate: nowIso(),
-          subfolders: [],
-          documents: [],
-        };
-        folders.set(scrumFolderId, scrumFolder);
-        testFolder.subfolders.push(scrumFolderId);
+          // Scrum-Ordner im Test-Ordner anlegen
+          const scrumFolderId = `${testFolderId}-design`;
+          const scrumFolder: Folder = {
+            id: scrumFolderId,
+            name: 'Design',
+            parentId: testFolderId,
+            createdDate: nowIso(),
+            subfolders: [],
+            documents: [],
+          };
+          folders.set(scrumFolderId, scrumFolder);
+          testFolder.subfolders.push(scrumFolderId);
 
-        // Datei im Test-Ordner anlegen
-        const falschId = `csv-${bin.jahr}-f2-falsch`;
-        const falschDoc: Doc = {
-          id: falschId,
-          name: 'falsch_benannt.csv',
-          size: 1234,
-          createdDate: nowIso(),
-          type: 'text/csv',
-          parentId: testFolderId,
-        };
-        documents.set(falschId, falschDoc);
-        testFolder.documents.push(falschId);
+          // Datei im Test-Ordner anlegen
+          const falschId = `csv-${bin.jahr}-f2-falsch`;
+          const falschDoc: Doc = {
+            id: falschId,
+            name: 'falsch_benannt.csv',
+            size: 1234,
+            createdDate: nowIso(),
+            type: 'text/csv',
+            parentId: testFolderId,
+          };
+          documents.set(falschId, falschDoc);
+          testFolder.documents.push(falschId);
+        }
       }
     }
   });

--- a/src/hooks/useFolderNavigation.ts
+++ b/src/hooks/useFolderNavigation.ts
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback } from 'react';
+import { useState, useRef, useCallback, useEffect } from 'react';
 import type { Item, FolderResponse, PathItem } from '@/@types/fileExplorer';
 import useDmsApiSelector from '@hooks/useDmsApiSelector';
 import { sleep } from '@utils/fileHelpers';
@@ -10,10 +10,28 @@ import { sleep } from '@utils/fileHelpers';
 export function useFolderNavigation() {
   const api = useDmsApiSelector();
   const [items, setItems] = useState<Item[]>([]);
-  const currentFolderIdRef = useRef<string>('root');
-  const [currentPath, setCurrentPath] = useState<PathItem[]>([
-    { id: 'root', name: 'root' },
-  ]);
+  // Restore persisted folder id and path if available
+  const initialFolderId = (() => {
+    try {
+      const saved = localStorage.getItem('dmsCurrentFolderId');
+      return saved || 'root';
+    } catch {
+      return 'root';
+    }
+  })();
+  const currentFolderIdRef = useRef<string>(initialFolderId);
+  const [currentPath, setCurrentPath] = useState<PathItem[]>(() => {
+    try {
+      const saved = localStorage.getItem('dmsCurrentPath');
+      if (saved) {
+        const parsed = JSON.parse(saved) as PathItem[];
+        if (Array.isArray(parsed) && parsed.length > 0) return parsed;
+      }
+    } catch {
+      // ignore
+    }
+    return [{ id: 'root', name: 'root' }];
+  });
   const refreshInProgressRef = useRef(false);
   const itemsRef = useRef<Item[]>(items);
 
@@ -27,6 +45,22 @@ export function useFolderNavigation() {
       ? currentPath[currentPath.length - 1].name
       : 'documents') || 'documents';
 
+  // Persist helpers
+  const persistFolderId = (id: string) => {
+    try {
+      localStorage.setItem('dmsCurrentFolderId', id);
+    } catch {
+      // ignore
+    }
+  };
+  const persistPath = (path: PathItem[]) => {
+    try {
+      localStorage.setItem('dmsCurrentPath', JSON.stringify(path));
+    } catch {
+      // ignore
+    }
+  };
+
   const refresh = useCallback(async () => {
     if (refreshInProgressRef.current) return;
     refreshInProgressRef.current = true;
@@ -35,6 +69,8 @@ export function useFolderNavigation() {
         currentFolderIdRef.current
       )) as FolderResponse;
       currentFolderIdRef.current = folder.folders?.id ?? folder.id ?? 'root';
+      // persist resolved folder id (in case API normalized it)
+      persistFolderId(currentFolderIdRef.current);
       const docs: Item[] = (folder.documents || []).map((d) => ({
         id: d.id,
         name: d.name,
@@ -50,6 +86,10 @@ export function useFolderNavigation() {
         uploadDate: f.createdDate ?? new Date().toISOString(),
         itemType: 'folder' as const,
       }));
+      // Alphabetisch sortieren (case-insensitive), Ordner vor Dateien
+      const collator = new Intl.Collator(undefined, { sensitivity: 'base' });
+      subfolders.sort((a, b) => collator.compare(a.name, b.name));
+      docs.sort((a, b) => collator.compare(a.name, b.name));
       const allItems = [...subfolders, ...docs];
       setItems(allItems);
     } catch {
@@ -63,18 +103,24 @@ export function useFolderNavigation() {
     if (name == 'root') return;
     if (!id || !name) return;
     const newElement = { id: id, name: name };
-    setCurrentPath((prev) => [...prev, newElement]);
+    setCurrentPath((prev) => {
+      const next = [...prev, newElement];
+      persistPath(next);
+      return next;
+    });
   }, []);
 
   const handleOpenFolder = async (id: string, name: string) => {
     if (id != currentFolderIdRef.current) {
       try {
         currentFolderIdRef.current = id;
+        persistFolderId(id);
         buildPathFromFolder(id, name);
         refresh();
       } catch {
         await sleep(200);
         currentFolderIdRef.current = id;
+        persistFolderId(id);
         buildPathFromFolder(id, name);
         refresh();
       }
@@ -99,12 +145,19 @@ export function useFolderNavigation() {
       }
 
       currentFolderIdRef.current = id;
+      persistFolderId(id);
       setCurrentPath(newPath);
+      persistPath(newPath);
       refresh();
     } else {
       refresh();
     }
   };
+
+  // Keep persisted path in sync if it changes externally
+  useEffect(() => {
+    persistPath(currentPath);
+  }, [currentPath]);
 
   return {
     items,

--- a/src/hooks/usePreview.ts
+++ b/src/hooks/usePreview.ts
@@ -22,6 +22,7 @@ export function usePreview({ items, showSnack }: UsePreviewProps) {
     name: string;
     type: string | undefined;
   } | null>(null);
+  const [inProgressId, setInProgressId] = useState<string | null>(null);
 
   const handleCloseViewer = () => {
     setViewerOpen(false);
@@ -31,6 +32,11 @@ export function usePreview({ items, showSnack }: UsePreviewProps) {
 
   const handleConvertOfficeToPdf = async (docId: string) => {
     try {
+      // Prevent double-trigger if same doc is already being processed or viewer open for it
+      if (inProgressId === docId || (viewerOpen && viewerFile?.id === docId)) {
+        return;
+      }
+      setInProgressId(docId);
       const doc = items.find((i) => i.id === docId);
       if (!doc) return;
 
@@ -39,7 +45,7 @@ export function usePreview({ items, showSnack }: UsePreviewProps) {
       setViewerLoading(true);
       setViewerOpen(true);
 
-      const isOfficeDoc = /\.(docx?|pptx?)$/i.test(doc.name);
+      const isOfficeDoc = /\.(docx?|pptx?|xlsx?)$/i.test(doc.name);
 
       if (!isOfficeDoc) {
         // Regular file (PDF, image, text, etc.)
@@ -71,6 +77,8 @@ export function usePreview({ items, showSnack }: UsePreviewProps) {
       );
       setViewerLoading(false);
       setViewerOpen(false);
+    } finally {
+      setInProgressId(null);
     }
   };
 

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -36,7 +36,13 @@ export function useSearch(items: Item[], selectedTags: TagEntity[] = []) {
       filtered = filtered.filter((i) => i.name.toLowerCase().includes(q));
     }
 
-    return filtered;
+    // Sort alphabetically (case-insensitive). Keep folders before files if both exist.
+    const collator = new Intl.Collator(undefined, { sensitivity: 'base' });
+    const folders = filtered.filter((i) => i.itemType === 'folder');
+    const files = filtered.filter((i) => i.itemType !== 'folder');
+    folders.sort((a, b) => collator.compare(a.name, b.name));
+    files.sort((a, b) => collator.compare(a.name, b.name));
+    return [...folders, ...files];
   };
 
   // Update filtered items when items, search query, or selected tags change

--- a/src/hooks/useTags.ts
+++ b/src/hooks/useTags.ts
@@ -12,32 +12,89 @@ const useTags = () => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  // Module-level cache and in-flight promise for de-duplication across hook instances
+  // Note: These live across component instances during the app lifetime
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const globalAny = globalThis as any;
+  if (!globalAny.__DMS_TAGS_CACHE__) {
+    globalAny.__DMS_TAGS_CACHE__ = {
+      data: null as TagEntity[] | null,
+      inFlight: null as Promise<TagEntity[]> | null,
+    };
+  }
+  const tagsCache: {
+    data: TagEntity[] | null;
+    inFlight: Promise<TagEntity[]> | null;
+  } = globalAny.__DMS_TAGS_CACHE__;
+
   // Fetch all tags
-  const fetchTags = useCallback(async () => {
-    setLoading(true);
-    setError(null);
-    try {
-      const fetchedTags = await api.getAllTags();
-      setTags(fetchedTags);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to fetch tags');
-      console.error('Error fetching tags:', err);
-    } finally {
-      setLoading(false);
-    }
-  }, [api]);
+  const fetchTags = useCallback(
+    async (force = false): Promise<TagEntity[]> => {
+      setError(null);
+
+      // Serve from cache if available and not forced
+      if (!force && tagsCache.data) {
+        setTags(tagsCache.data);
+        return tagsCache.data;
+      }
+
+      // Join in-flight request if exists
+      if (tagsCache.inFlight) {
+        setLoading(true);
+        try {
+          const res = await tagsCache.inFlight;
+          setTags(res);
+          return res;
+        } finally {
+          setLoading(false);
+        }
+      }
+
+      // Start new fetch
+      setLoading(true);
+      const p = api
+        .getAllTags()
+        .then((fetched) => {
+          tagsCache.data = fetched;
+          setTags(fetched);
+          return fetched;
+        })
+        .catch((err) => {
+          setError(err instanceof Error ? err.message : 'Failed to fetch tags');
+          console.error('Error fetching tags:', err);
+          throw err;
+        })
+        .finally(() => {
+          tagsCache.inFlight = null;
+          setLoading(false);
+        });
+      tagsCache.inFlight = p;
+      return p;
+    },
+    [api, tagsCache]
+  );
 
   // Load tags on mount
   useEffect(() => {
-    fetchTags();
-  }, [fetchTags]);
+    // If we already have a cache, hydrate local state only, avoid extra fetch
+    if (tagsCache.data) {
+      setTags(tagsCache.data);
+      return;
+    }
+    void fetchTags();
+  }, [fetchTags, tagsCache.data]);
 
   // Create a new tag
   const createTag = useCallback(
     async (tagName: string) => {
       try {
         const newTag = await api.createTag(tagName);
-        setTags((prev) => [...prev, newTag]);
+        // Update local state and cache
+        setTags((prev) => {
+          const next = [...prev, newTag];
+          tagsCache.data = next;
+          return next;
+        });
         return newTag;
       } catch (err) {
         const message =
@@ -46,7 +103,7 @@ const useTags = () => {
         throw new Error(message);
       }
     },
-    [api]
+    [api, tagsCache]
   );
 
   // Update an existing tag
@@ -54,9 +111,11 @@ const useTags = () => {
     async (tagUuid: string, tagName: string) => {
       try {
         const updatedTag = await api.updateTag(tagUuid, tagName);
-        setTags((prev) =>
-          prev.map((t) => (t.uuid === tagUuid ? updatedTag : t))
-        );
+        setTags((prev) => {
+          const next = prev.map((t) => (t.uuid === tagUuid ? updatedTag : t));
+          tagsCache.data = next;
+          return next;
+        });
         return updatedTag;
       } catch (err) {
         const message =
@@ -65,7 +124,7 @@ const useTags = () => {
         throw new Error(message);
       }
     },
-    [api]
+    [api, tagsCache]
   );
 
   // Delete a tag
@@ -73,7 +132,11 @@ const useTags = () => {
     async (tagUuid: string) => {
       try {
         await api.deleteTag(tagUuid);
-        setTags((prev) => prev.filter((t) => t.uuid !== tagUuid));
+        setTags((prev) => {
+          const next = prev.filter((t) => t.uuid !== tagUuid);
+          tagsCache.data = next;
+          return next;
+        });
       } catch (err) {
         const message =
           err instanceof Error ? err.message : 'Failed to delete tag';
@@ -81,7 +144,7 @@ const useTags = () => {
         throw new Error(message);
       }
     },
-    [api]
+    [api, tagsCache]
   );
 
   // Update tags on a document

--- a/src/i18n/de-DE/translation.json
+++ b/src/i18n/de-DE/translation.json
@@ -152,6 +152,7 @@
       "noDocsInSelection": "Keine Dateien in der Auswahl",
       "createFailed": "Erstellung fehlgeschlagen",
       "moved": "Verschoben",
+      "movedAndGroupsUpdated": "Verschoben und Studierendengruppen-Einschränkung angepasst",
       "moveFailed": "Verschieben fehlgeschlagen",
       "invalidMove": "Verschieben nicht möglich: Ein Ordner kann nicht in sich selbst oder seine Unterordner verschoben werden",
       "alreadyInFolderFolder": "Verschieben nicht möglich: Der Ordner befindet sich bereits in dem ausgewählten Ordner",

--- a/src/i18n/en-US/translation.json
+++ b/src/i18n/en-US/translation.json
@@ -152,6 +152,7 @@
       "noDocsInSelection": "No files in selection",
       "createFailed": "Create failed",
       "moved": "Moved",
+      "movedAndGroupsUpdated": "Moved and updated study group restriction",
       "moveFailed": "Move failed",
       "invalidMove": "Cannot move a folder into itself or its descendant",
       "alreadyInFolderFolder": "Cannot move folder: it is already in the selected folder",

--- a/src/pages/DocumentManagement/FileExplorer.tsx
+++ b/src/pages/DocumentManagement/FileExplorer.tsx
@@ -294,6 +294,104 @@ export default function FileExplorer(): React.ReactElement {
           (f) => f.name === sourceFolderName && f.id !== sourceId
         );
 
+        // (Ancestorship precomputed below before the move)
+
+        // Precompute relationship and groups BEFORE the move
+        const originalGroupsPre = parseStudyGroupIds(
+          sourceFolderData.studyGroupIds ??
+            sourceFolderData.folders?.studyGroupIds
+        );
+        const targetGroupsPre = parseStudyGroupIds(
+          targetFolderData.studyGroupIds ??
+            targetFolderData.folders?.studyGroupIds
+        );
+        const isTargetAncestorPreMove = await (async (
+          maybeAncestorId: string | undefined,
+          folderId: string
+        ) => {
+          if (!maybeAncestorId) return false;
+          try {
+            let current: string | undefined = folderId;
+            let depth = 0;
+            while (current && depth < MAX_PATH_DEPTH) {
+              const fd = (await api.getFolder(current)) as FolderResponse;
+              const md = parseFolderMetadata(fd, current);
+              const parent = md.parentId;
+              if (!parent) break;
+              if (parent === maybeAncestorId) return true;
+              if (parent === 'root') break;
+              current = parent;
+              depth += 1;
+            }
+          } catch {
+            // ignore
+          }
+          return false;
+        })(targetId, sourceId);
+
+        // Helper: after moving, decide final study group restriction and persist if changed.
+        // Returns true if groups were changed compared to original.
+        const applyStudyGroupPolicyAfterMove = async (): Promise<boolean> => {
+          try {
+            const originalGroups = originalGroupsPre;
+            const targetGroups = targetGroupsPre;
+            const targetIsAncestor = isTargetAncestorPreMove;
+
+            // Determine final groups:
+            // 1. Moving "up" (into ancestor): keep original groups exactly.
+            // 2. Target unrestricted (no targetGroups): keep original groups.
+            // 3. Original empty (unrestricted): adopt targetGroups (restrict now) -> changed if targetGroups not empty.
+            // 4. Original subset of targetGroups: keep original.
+            // 5. Otherwise: replace with targetGroups (intersection not allowed -> align fully).
+            let finalGroups: string[] = originalGroups.slice();
+            let changed = false;
+
+            if (targetIsAncestor) {
+              // Preserve
+              finalGroups = originalGroups.slice();
+            } else if (targetGroups.length === 0) {
+              finalGroups = originalGroups.slice();
+            } else if (originalGroups.length === 0) {
+              finalGroups = targetGroups.slice();
+              changed = targetGroups.length > 0;
+            } else {
+              const isSubset = originalGroups.every((g) =>
+                targetGroups.includes(g)
+              );
+              if (isSubset) {
+                finalGroups = originalGroups.slice();
+              } else {
+                finalGroups = targetGroups.slice();
+                changed = true;
+              }
+            }
+
+            // Compare sets to detect change even in ancestor/unrestricted cases (e.g. backend might drop groups)
+            const sameLength = finalGroups.length === originalGroups.length;
+            const sameContent =
+              sameLength &&
+              finalGroups.every((g) => originalGroups.includes(g));
+            if (!sameContent) changed = true;
+
+            // Persist only if there is a restriction (could be empty meaning unrestricted) OR if changed
+            if (changed) {
+              await api.updateFolderStudyGroups(sourceId, finalGroups);
+            } else {
+              // Ensure backend keeps groups if non-empty (avoid accidental wipe by move implementation)
+              if (finalGroups.length > 0) {
+                await api.updateFolderStudyGroups(sourceId, finalGroups);
+              }
+            }
+            return changed;
+          } catch (err) {
+            console.warn(
+              'StudyGroup policy application failed after move:',
+              err
+            );
+            return false;
+          }
+        };
+
         if (existingFolder) {
           fileOps.setConflictName(sourceFolderName);
           fileOps.setConflictType('folder');
@@ -309,10 +407,16 @@ export default function FileExplorer(): React.ReactElement {
 
                 await api.renameFolder(sourceId, newName);
                 await api.moveFolder(sourceId, targetId);
+                const changed = await applyStudyGroupPolicyAfterMove();
                 setItems((prev) => prev.filter((i) => i.id !== sourceId));
                 await refresh();
                 fileOps.showSnack(
-                  t('documentManagement.snack.moved', 'Moved'),
+                  changed
+                    ? t(
+                        'documentManagement.snack.movedAndGroupsUpdated',
+                        'Moved and updated study group restriction'
+                      )
+                    : t('documentManagement.snack.moved', 'Moved'),
                   'success'
                 );
               },
@@ -323,10 +427,16 @@ export default function FileExplorer(): React.ReactElement {
               overwrite: async () => {
                 await api.deleteFolder(existingFolder.id);
                 await api.moveFolder(sourceId, targetId);
+                const changed = await applyStudyGroupPolicyAfterMove();
                 setItems((prev) => prev.filter((i) => i.id !== sourceId));
                 await refresh();
                 fileOps.showSnack(
-                  t('documentManagement.snack.moved', 'Moved'),
+                  changed
+                    ? t(
+                        'documentManagement.snack.movedAndGroupsUpdated',
+                        'Moved and updated study group restriction'
+                      )
+                    : t('documentManagement.snack.moved', 'Moved'),
                   'success'
                 );
               },
@@ -340,10 +450,16 @@ export default function FileExplorer(): React.ReactElement {
 
                 await api.renameFolder(sourceId, newName);
                 await api.moveFolder(sourceId, targetId);
+                const changed = await applyStudyGroupPolicyAfterMove();
                 setItems((prev) => prev.filter((i) => i.id !== sourceId));
                 await refresh();
                 fileOps.showSnack(
-                  t('documentManagement.snack.moved', 'Moved'),
+                  changed
+                    ? t(
+                        'documentManagement.snack.movedAndGroupsUpdated',
+                        'Moved and updated study group restriction'
+                      )
+                    : t('documentManagement.snack.moved', 'Moved'),
                   'success'
                 );
               },
@@ -356,7 +472,23 @@ export default function FileExplorer(): React.ReactElement {
           return;
         }
 
+        // Default, no-conflict move
         await api.moveFolder(sourceId, targetId);
+        const changed = await applyStudyGroupPolicyAfterMove();
+        setItems((prev) => prev.filter((i) => i.id !== sourceId));
+        await refresh();
+        fileOps.showSnack(
+          changed
+            ? t(
+                'documentManagement.snack.movedAndGroupsUpdated',
+                'Moved and updated study group restriction'
+              )
+            : t('documentManagement.snack.moved', 'Moved'),
+          'success'
+        );
+        fileOps.setMoveChooserOpen(false);
+        fileOps.setMoveSourceId(null);
+        return;
       } else {
         // Document move logic
         // Note: getDocumentMetadata is optional, so we skip parent check if not available
@@ -452,7 +584,6 @@ export default function FileExplorer(): React.ReactElement {
 
         await api.moveDocument(sourceId, targetId);
       }
-
       setItems((prev) => prev.filter((i) => i.id !== sourceId));
       fileOps.showSnack(
         t('documentManagement.snack.moved', 'Moved'),
@@ -572,7 +703,7 @@ export default function FileExplorer(): React.ReactElement {
         selectedTags={selectedTags}
         onTagFilterChange={setSelectedTags}
         onRefetchTags={async () => {
-          await tagsHook.fetchTags();
+          await tagsHook.fetchTags(true); // force one refresh of global cache
           await refresh();
         }}
         onDeleteTag={async (tagUuid: string) => {


### PR DESCRIPTION
Attempt fixing the following problems:
1. Der FileViewer hat keine Loading anzeige. Ich hatte die eingentlich implementiert aber die wird nur ganz kurz am ende angezeigt, nicht wenn das loading actually beginnt.
2. Wenn man einen Restricted Folder verschiebt wird die studyGroupId restriction entfernt. Anstelle dessen sollte die studyGroup Restriction beibehalten werden, wenn man in Überordner verschiebt. Verschiebt man in einen nächstgelegenen Unterordner muss ein check passieren, ob die derzeitige studyGroup im unterordner existiert. Wenn ja: Restriction beibehalten; Wenn nein: Restriction auf die des neuen überordners anpassen und snack anzeigen, dass nicht nur verschoben sondern auch die studyGroup restriction angepasst wurde.
3. xlsx funktioniert nicht in der preview
3.1 HTML und CSV Dateien werden (vermutlich als plain text mimetype gewertet und daher) sehr komisch im fileviewer angezeigt. diese lieber nicht erlauben. Andererseits .xlsx müsste eigentlich an die pdf converter api gesendet werden können, stattdessen wird für diese "no preview available" angezeigt.
4. manche api calls (preview, tags) werden generell noch mehrfach hintereinander aufgerufen (und bei tags in Momenten, in denen sie gar nicht benötigt werden würde)
5. Im FileExplorer werden die Files nicht alphabetisch sortiert angezeigt.
5.1 Gleiches gilt auch in der Create Folder und restrict visibility UI (Da wo auch die x buttons zum entfernen sind, in den dropdown menüs ist alles alphabetisch)
6. After Page Refresh I think it would be nice to stay in the current folder, so i did that